### PR TITLE
Support Jackson 2.9.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,16 @@ cache:
   directories:
     - $HOME/.m2
 
-script: ./mvnw clean verify
+env:
+  matrix:
+    - # as specified in pom.xml
+    - SUFFIX='-D jackson.version=2.5.5'
+    - SUFFIX='-D jackson.version=2.6.7'
+    - SUFFIX='-D jackson.version=2.7.9'
+    - SUFFIX='-D jackson.version=2.8.11'
+    - SUFFIX='-D jackson.version=2.9.3'
+
+script: ./mvnw clean verify $SUFFIX
 
 after_success:
   - ./mvnw coveralls:report

--- a/jackson-datatype-problem/pom.xml
+++ b/jackson-datatype-problem/pom.xml
@@ -26,7 +26,7 @@
     </scm>
 
     <properties>
-        <jackson.version>2.6.1</jackson.version>
+        <jackson.version>2.9.3</jackson.version>
     </properties>
 
     <dependencies>

--- a/jackson-datatype-problem/pom.xml
+++ b/jackson-datatype-problem/pom.xml
@@ -26,7 +26,7 @@
     </scm>
 
     <properties>
-        <jackson.version>2.9.3</jackson.version>
+        <jackson.version>2.5.0</jackson.version>
     </properties>
 
     <dependencies>

--- a/jackson-datatype-problem/src/main/java/org/zalando/problem/ExceptionalMixin.java
+++ b/jackson-datatype-problem/src/main/java/org/zalando/problem/ExceptionalMixin.java
@@ -3,6 +3,9 @@ package org.zalando.problem;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
@@ -18,7 +21,9 @@ interface ExceptionalMixin {
     @JsonInclude(NON_NULL)
     ThrowableProblem getCause();
 
-    @JsonIgnore
+    // decision about inclusion is up to derived mixins
+    @JsonProperty("stacktrace")
+    @JsonSerialize(contentUsing = ToStringSerializer.class)
     StackTraceElement[] getStackTrace();
 
     @JsonIgnore

--- a/jackson-datatype-problem/src/main/java/org/zalando/problem/ExceptionalWithoutStacktraceMixin.java
+++ b/jackson-datatype-problem/src/main/java/org/zalando/problem/ExceptionalWithoutStacktraceMixin.java
@@ -1,14 +1,16 @@
 package org.zalando.problem;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.ser.std.ToStringSerializer;
 
-interface ExceptionalWithStacktraceMixin extends ExceptionalMixin {
+@JsonIgnoreProperties(ignoreUnknown = true)
+interface ExceptionalWithoutStacktraceMixin extends ExceptionalMixin {
 
     @Override
-    @JsonProperty("stacktrace")
-    @JsonSerialize(contentUsing = ToStringSerializer.class)
+    @JsonIgnore
     StackTraceElement[] getStackTrace();
 
 }

--- a/jackson-datatype-problem/src/main/java/org/zalando/problem/ProblemModule.java
+++ b/jackson-datatype-problem/src/main/java/org/zalando/problem/ProblemModule.java
@@ -58,8 +58,8 @@ public final class ProblemModule extends Module {
         final SimpleModule module = new SimpleModule();
 
         module.setMixInAnnotation(Exceptional.class, stackTraces ?
-                ExceptionalWithStacktraceMixin.class :
-                ExceptionalMixin.class);
+                ExceptionalMixin.class :
+                ExceptionalWithoutStacktraceMixin.class);
 
         module.setMixInAnnotation(DefaultProblem.class, AbstractThrowableProblemMixIn.class);
         module.setMixInAnnotation(Problem.class, ProblemMixIn.class);

--- a/jackson-datatype-problem/src/test/java/org/zalando/problem/ProblemMixInTest.java
+++ b/jackson-datatype-problem/src/test/java/org/zalando/problem/ProblemMixInTest.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static com.jayway.jsonassert.JsonAssert.with;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasSize;
@@ -23,7 +24,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.hobsoft.hamcrest.compose.ComposeMatchers.hasFeature;
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.zalando.problem.Status.BAD_REQUEST;
 
 final class ProblemMixInTest {
@@ -105,7 +105,8 @@ final class ProblemMixInTest {
         final String json = mapper.writeValueAsString(problem);
 
         with(json)
-                .assertNotDefined("$.stacktrace");
+                .assertNotDefined("$.stacktrace")
+                .assertNotDefined("$.stackTrace"); // default name, just in case our renaming didn't apply
     }
 
     @Test


### PR DESCRIPTION
Fixes #53

Looks like Jackson changed how some annotations interact with inheritence:
- `@JsonIgnoreProperties` is no longer inhereted
- `@JsonIgnore` is inhereted now