### PR TITLE
Override toString for Status, as a status reason is always provided a…

### DIFF
--- a/problem/src/main/java/org/zalando/problem/Status.java
+++ b/problem/src/main/java/org/zalando/problem/Status.java
@@ -2,6 +2,8 @@ package org.zalando.problem;
 
 import org.apiguardian.api.API;
 
+import javax.annotation.Nonnull;
+
 import static org.apiguardian.api.API.Status.MAINTAINED;
 
 /**
@@ -278,8 +280,18 @@ public enum Status implements StatusType {
      * @return the reason phrase.
      */
     @Override
+    @Nonnull
     public String getReasonPhrase() {
         return reason;
     }
 
+    /**
+     * Get the Status String representation.
+     *
+     * @return the status code and reason.
+     */
+    @Override
+    public String toString() {
+        return getStatusCode() + " " + getReasonPhrase();
+    }
 }

--- a/problem/src/test/java/org/zalando/problem/StatusTest.java
+++ b/problem/src/test/java/org/zalando/problem/StatusTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
 import static org.hamcrest.Matchers.emptyOrNullString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -19,4 +20,10 @@ final class StatusTest {
                 assertThat(status, hasFeature("reason phrase", StatusType::getReasonPhrase, is(not(emptyOrNullString())))));
     }
 
+    @Test
+    void shouldHaveMeaningfulToString() {
+        Status notFound = Status.NOT_FOUND;
+
+        assertThat(notFound.toString(), equalTo("404 Not Found"));
+    }
 }


### PR DESCRIPTION
Override toString for Status Enum.
As a status reason is always provided add nonnullable annotation to getReason method.

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add toString override to get a nice string representation of a Status.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I add the toString overload to the Status Enum as i think it is more appropriate to override toString for an enum that holds status code and description.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [X ] I have updated the documentation accordingly.
- [X ] I have added tests to cover my changes.
