### PR TITLE
feat(Status): Add a method to create a Status instance from an integer

### DIFF
--- a/jackson-datatype-problem/pom.xml
+++ b/jackson-datatype-problem/pom.xml
@@ -15,7 +15,7 @@
         <developerConnection>scm:git:git@github.com:zalando/problem.git</developerConnection>
     </scm>
     <properties>
-        <jackson.version>2.9.8</jackson.version>
+        <jackson.version>2.9.9</jackson.version>
     </properties>
     <dependencies>
         <dependency>

--- a/problem/pom.xml
+++ b/problem/pom.xml
@@ -44,6 +44,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit-jupiter.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>java-hamcrest</artifactId>
             <version>2.0.0.0</version>

--- a/problem/src/main/java/org/zalando/problem/Status.java
+++ b/problem/src/main/java/org/zalando/problem/Status.java
@@ -3,6 +3,7 @@ package org.zalando.problem;
 import org.apiguardian.api.API;
 
 import javax.annotation.Nonnull;
+import java.util.Arrays;
 
 import static org.apiguardian.api.API.Status.MAINTAINED;
 
@@ -266,6 +267,20 @@ public enum Status implements StatusType {
     Status(final int statusCode, final String reasonPhrase) {
         this.code = statusCode;
         this.reason = reasonPhrase;
+    }
+
+    /**
+     * Creates a Status instance from the given code.
+     *
+     * @param code the HTTP code as a number
+     * @return the correct enum value for this status code.
+     * @throws IllegalArgumentException if the given code does not correspond to a known HTTP status.
+     */
+    public static Status ofCode(int code) {
+        return Arrays.stream(Status.values())
+                .filter(status -> status.getStatusCode() == code)
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("There is no known status for this code (" + code + ")."));
     }
 
     /**

--- a/problem/src/test/java/org/zalando/problem/StatusTest.java
+++ b/problem/src/test/java/org/zalando/problem/StatusTest.java
@@ -1,6 +1,9 @@
 package org.zalando.problem;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.stream.Stream;
 
@@ -25,5 +28,26 @@ final class StatusTest {
         Status notFound = Status.NOT_FOUND;
 
         assertThat(notFound.toString(), equalTo("404 Not Found"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "409, Conflict",
+            "404, Not Found",
+            "200, OK",
+            "500, Internal Server Error"
+    })
+    void shouldHaveCorrectValueFromCode(int code, String line) {
+        Status statusFromCode = Status.ofCode(code);
+
+        assertThat(statusFromCode.getStatusCode(), equalTo(code));
+        assertThat(statusFromCode.getReasonPhrase(), equalTo(line));
+    }
+
+    @Test
+    void shouldThrowOnNonExistingCode() {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> {
+            Status.ofCode(111);
+        });
     }
 }


### PR DESCRIPTION
## Description

This PR introduces a builder method to create a Status instance from an integer code.

## Motivation and Context

In my application, I sometimes need to create a Problem and I already have the status code as an integer. This new method gives me a convenient and elegant way to create a Status instance from the integer code without having to create a separate factory class.

This is a purely "quality of life" change but it shouldn't introduce any overhead or performance issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
