### PR TITLE
Add further nullability annotations to improve interop

### DIFF
--- a/problem/src/main/java/org/zalando/problem/Problem.java
+++ b/problem/src/main/java/org/zalando/problem/Problem.java
@@ -96,15 +96,17 @@ public interface Problem {
         return GenericProblems.create(status).build();
     }
 
-    static ThrowableProblem valueOf(final StatusType status, final String detail) {
+    static ThrowableProblem valueOf(final StatusType status, @Nullable final String detail) {
         return GenericProblems.create(status).withDetail(detail).build();
     }
 
-    static ThrowableProblem valueOf(final StatusType status, final URI instance) {
+    static ThrowableProblem valueOf(final StatusType status, @Nullable final URI instance) {
         return GenericProblems.create(status).withInstance(instance).build();
     }
 
-    static ThrowableProblem valueOf(final StatusType status, final String detail, final URI instance) {
+    static ThrowableProblem valueOf(final StatusType status,
+                                    @Nullable final String detail,
+                                    @Nullable final URI instance) {
         return GenericProblems.create(status).withDetail(detail).withInstance(instance).build();
     }
 

--- a/problem/src/main/java/org/zalando/problem/ProblemBuilder.java
+++ b/problem/src/main/java/org/zalando/problem/ProblemBuilder.java
@@ -71,7 +71,7 @@ public final class ProblemBuilder {
      * @return this for chaining
      * @throws IllegalArgumentException if key is any of type, title, status, detail or instance
      */
-    public ProblemBuilder with(final String key, final Object value) throws IllegalArgumentException {
+    public ProblemBuilder with(final String key, @Nullable final Object value) throws IllegalArgumentException {
         if (RESERVED_PROPERTIES.contains(key)) {
             throw new IllegalArgumentException("Property " + key + " is reserved");
         }

--- a/problem/src/test/java/org/zalando/problem/ProblemBuilderTest.java
+++ b/problem/src/test/java/org/zalando/problem/ProblemBuilderTest.java
@@ -79,6 +79,19 @@ class ProblemBuilderTest {
 
         assertThat(problem.getParameters(), hasEntry("foo", "bar"));
     }
+
+    @Test
+    void shouldCreateProblemWithNullParameter() {
+        final ThrowableProblem problem = Problem.builder()
+                .withType(type)
+                .withTitle("Out of Stock")
+                .withStatus(BAD_REQUEST)
+                .with("foo", "will-be-overridden")
+                .with("foo", null)
+                .build();
+
+        assertThat(problem.getParameters(), hasEntry("foo", null));
+    }
     
     @Test
     void shouldCreateProblemWithCause() {


### PR DESCRIPTION
## Description
This PR marks more method parameters as explicitly nullable.
There are already lots of these annotations in place, but adding a few more makes interoperability with Kotlin a bit smoother, for example.

## Motivation and Context
Using this library with Kotlin is currently giving us some compiler errors when enabling [strict JSR-305 support](https://kotlinlang.org/docs/java-interop.html#jsr-305-support).

For example, even although the underlying `ProblemBuilder#withDetail` method explicitly allows a `null` string value, Kotlin somehow isn't able to infer that `detail` parameter in the `Problem#valueOf()` method is also nullable.

Hence we see compiler errors when trying to pass in a nullable string, e.g. the `message` field of a `kotlin.Throwable`:
![image](https://user-images.githubusercontent.com/138615/121347105-1816ff80-c927-11eb-80e9-6a93770a89db.png)

Compiling against the changes in this PR resolved this class of errors throughout our project.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
None of the above?

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
