### PR TITLE
Fixes #329: wrong name in problem/module-info.java

### DIFF
--- a/problem/src/main/java/module-info.java
+++ b/problem/src/main/java/module-info.java
@@ -1,6 +1,6 @@
-module org.zalando.problem.gson {
+module org.zalando.problem {
     requires static org.apiguardian.api;
     requires transitive com.google.gson;
     requires transitive org.zalando.problem;
-    exports org.zalando.problem.gson;
+    exports org.zalando.problem;
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Issue: #329 
module-info for org.zalando.problem is incorrectly named org.zalando.problem.gson. This causes problem when we try to use org.zalando.problem with the Java 9 module system.

## Motivation and Context
Fixes a bug in the naming of the org.zalando.problem module.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
