### PR TITLE
Fix org.zalando.problem module being dependent on self

### DIFF
--- a/problem/src/main/java/module-info.java
+++ b/problem/src/main/java/module-info.java
@@ -1,6 +1,5 @@
 module org.zalando.problem {
     requires static org.apiguardian.api;
     requires transitive com.google.gson;
-    requires transitive org.zalando.problem;
     exports org.zalando.problem;
 }


### PR DESCRIPTION
## Description
When attempting to use org.zalando.problem module with Java 9 module system, we end up getting the error:
`"InvalidModuleDescriptorException Dependence on self"`

This is caused by a bug in the `module-info.java` for `org.zalando.problem`, where the module declares a transitive dependency on itself.

## Motivation and Context
To be able to use `org.zalando.problem` with Java modules, as stated in the readme: https://github.com/zalando/problem#java-modules.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
