### PR TITLE
#426 module-info.java is placed in the wrong jar 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -264,7 +264,7 @@
                 <plugin>
                     <groupId>org.moditect</groupId>
                     <artifactId>moditect-maven-plugin</artifactId>
-                    <version>1.0.0.RC2</version>
+                    <version>1.0.0.RC3</version>
                     <!-- 
                         This plugin provides most of the heavy lifting to support Java 9+,
                         until we move away from Java 8 (in favor of 11 or a newer LTS).
@@ -288,7 +288,7 @@
                                 <goal>add-module-info</goal>
                             </goals>
                             <configuration>
-                                <jvmVersion>9</jvmVersion>
+                                <jvmVersion>base</jvmVersion>
                                 <module>
                                     <moduleInfoFile>${project.build.sourceDirectory}/module-info.java</moduleInfoFile>
                                 </module>


### PR DESCRIPTION
## Description

Fixes #426 

File `module-info.class` was moved from `META-INF/versions/9` to the root folder of the jar.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
