### PR TITLE
Updates actions/cache to v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v1
     - name: Cache
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.m2
         key: m2


### PR DESCRIPTION
## Description
Updates actions/cache to v4

## Motivation and Context
> Your workflow is using a version of actions/cache that is scheduled for deprecation, actions/cache@v1. Please update your workflow to use either v3 or v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

https://github.com/actions/cache/discussions/1510:
> We recommend upgrading to version v4 or v3 as soon as possible before March 1st, 2025.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
