### PR TITLE
Migrate to Central Portal

### DIFF
--- a/jackson-datatype-problem/pom.xml
+++ b/jackson-datatype-problem/pom.xml
@@ -9,6 +9,7 @@
         <version>0.28.0-SNAPSHOT</version>
     </parent>
     <artifactId>jackson-datatype-problem</artifactId>
+    <name>${artifactId}</name>
     <properties>
         <jackson.version>2.13.4.1</jackson.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,9 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.zalando</groupId>
     <artifactId>problem-parent</artifactId>
+    <name>problem</name>
     <version>0.28.0-SNAPSHOT</version>
+    <description>library that implements application/problem+json</description>
     <packaging>pom</packaging>
     <url>https://github.com/zalando/problem</url>
     <inceptionYear>2015</inceptionYear>
@@ -35,16 +37,6 @@
         <connection>scm:git:git@github.com:zalando/problem.git</connection>
         <developerConnection>scm:git:git@github.com:zalando/problem.git</developerConnection>
     </scm>
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -475,14 +467,14 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <deploymentName>${project.name}:${project.version}</deploymentName>
+                            <autoPublish>true</autoPublish>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/problem-gson/pom.xml
+++ b/problem-gson/pom.xml
@@ -9,6 +9,7 @@
         <version>0.28.0-SNAPSHOT</version>
     </parent>
     <artifactId>problem-gson</artifactId>
+    <name>${artifactId}</name>
     <properties>
         <gson.version>2.9.0</gson.version>
     </properties>

--- a/problem/pom.xml
+++ b/problem/pom.xml
@@ -9,5 +9,6 @@
         <version>0.28.0-SNAPSHOT</version>
     </parent>
     <artifactId>problem</artifactId>
+    <name>${artifactId}</name>
     <description>An implementation of the application/problem+json draft.</description>
 </project>


### PR DESCRIPTION
## Description

Migrating from OSSRH to Central Portal for publishing of releases. See https://central.sonatype.org/publish/generate-portal-token/ for authentication. 

## Motivation and Context
See https://central.sonatype.org/faq/what-is-different-between-central-portal-and-legacy-ossrh/ 

- [x] fix `pom` violations
- [x] fix javadocs violations
- [x] requires #508 